### PR TITLE
Use default color for CLI input prompt

### DIFF
--- a/src/main/java/org/mcphackers/mcp/main/MainCLI.java
+++ b/src/main/java/org/mcphackers/mcp/main/MainCLI.java
@@ -85,7 +85,7 @@ public class MainCLI extends MCP {
 		int executeTimes = 0;
 		while (startedWithNoParams && !exit || !startedWithNoParams && executeTimes < 1) {
 			while (args.length < 1) {
-				System.out.print(new Ansi().fgBrightCyan().a("> ").fgRgb(255, 255, 255));
+				System.out.print(new Ansi().fgBrightCyan().a("> ").fgDefault());
 				String str = null;
 				try {
 					if (consoleInput.hasNext()) {


### PR DESCRIPTION
When using the CLI with a terminal in light mode, the input is currently unreadable because it is hardcoded white. Using `fgDefault` allows the CLI to choose an appropriate color.