### PR TITLE
Replace spin loops with blocking in `runCommand` and `performTask`

### DIFF
--- a/src/main/java/org/mcphackers/mcp/MCP.java
+++ b/src/main/java/org/mcphackers/mcp/MCP.java
@@ -9,6 +9,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -123,8 +124,13 @@ public abstract class MCP {
 		}
 
 		pool.shutdown();
-		while (!pool.isTerminated()) {
-		}
+		while (true) {
+			try {
+				if (pool.awaitTermination(500, TimeUnit.MILLISECONDS)) break;
+			} catch (InterruptedException err) {
+				throw new RuntimeException("Main thread was interrupted while performTask was waiting for tasks to finish", err );
+			}
+		};
 		triggerEvent(MCPEvent.FINISHED_TASKS);
 
 		byte result = result1.byteValue();


### PR DESCRIPTION
Yes, I know, the blocking APIs for `Process` aren't very clean and generally suck, but I think ***not wasting 2-3 CPU entire cores while running tasks*** is more than worth a small amount of added complexity. CPU time doesn't exactly grow on trees.

I've marked this PR to allow edits by maintainers, feel free to turn the stderr/stdout lambdas in Util.runProcess into a function/do whatever else you want.

But please merge this :)

My CPU (and many others) will thank you later