### PR TITLE
Ignore blank inputs in CLI

### DIFF
--- a/src/main/java/org/mcphackers/mcp/main/MainCLI.java
+++ b/src/main/java/org/mcphackers/mcp/main/MainCLI.java
@@ -88,7 +88,7 @@ public class MainCLI extends MCP {
 				System.out.print(new Ansi().fgBrightCyan().a("> ").fgDefault());
 				String str = null;
 				try {
-					if (consoleInput.hasNext()) {
+					if (consoleInput.hasNextLine()) {
 						str = consoleInput.nextLine();
 					} else {
 						// Only seems to occur during EOF, might occur in other cases?
@@ -100,6 +100,9 @@ public class MainCLI extends MCP {
 					mode = TaskMode.EXIT;
 				} else {
 					str = str.trim();
+					if (str.length() == 0) {
+						continue;
+					}
 					System.out.print(new Ansi().fgDefault());
 					args = str.split(" ");
 				}


### PR DESCRIPTION
This PR tweaks the behavior of the CLI when the user enters empty or blank lines.

The current behavior appears slightly buggy. Here are the steps to reproduce:

1. Run `./gradlew build`
2. Run `java -jar ./build/libs/RetroMCP-Java-CLI.jar`
3. Press enter a few times (i.e., enter a few blank lines)
4. Observe that the prompt '>' is not reprinted.
5. Enter a command such as 'help'
6. Observe that it prints `Unknown command. [...]` for every time that you pressed enter earlier, then it prints the results of the 'help' command.

This PR makes it to where blank input lines are ignored. Specifically:

- No error message is printed for each blank line
- The prompt '>' is reprinted
