### PR TITLE
fix: fixed the apply patches stage in the GUI

### DIFF
--- a/src/main/java/org/mcphackers/mcp/MCPPaths.java
+++ b/src/main/java/org/mcphackers/mcp/MCPPaths.java
@@ -37,10 +37,9 @@ public class MCPPaths {
 	public static final String MAPPINGS = CONF + "mappings.tiny";
 	public static final String EXC = CONF + "exceptions.exc";
 	public static final String ACCESS = CONF + "%s.access";
-	public static final String PATCHES = CONF + "%s.patch";
+	public static final String PATCHES = "patches/%s.patch";
 	public static final String VERSION = CONF + "version.json";
 
-	public static final String PATCH = "patches/%s.patch";
 
 	public static final String UPDATE_JAR = "update.jar";
 

--- a/src/main/java/org/mcphackers/mcp/tasks/TaskApplyPatch.java
+++ b/src/main/java/org/mcphackers/mcp/tasks/TaskApplyPatch.java
@@ -1,6 +1,6 @@
 package org.mcphackers.mcp.tasks;
 
-import static org.mcphackers.mcp.MCPPaths.PATCH;
+import static org.mcphackers.mcp.MCPPaths.PATCHES;
 import static org.mcphackers.mcp.MCPPaths.SOURCE;
 
 import java.io.ByteArrayOutputStream;
@@ -23,7 +23,7 @@ public class TaskApplyPatch extends TaskStaged {
 	protected Stage[] setStages() {
 		return new Stage[] {
 				stage(getLocalizedStage("patching"), 0, () -> {
-					final Path patchesPath = MCPPaths.get(mcp, PATCH, side);
+					final Path patchesPath = MCPPaths.get(mcp, PATCHES, side);
 					final Path srcPath = MCPPaths.get(mcp, SOURCE, side);
 					patch(this, srcPath, srcPath, patchesPath);
 				})

--- a/src/main/java/org/mcphackers/mcp/tasks/TaskCreatePatch.java
+++ b/src/main/java/org/mcphackers/mcp/tasks/TaskCreatePatch.java
@@ -21,7 +21,7 @@ public class TaskCreatePatch extends TaskStaged {
 				stage(getLocalizedStage("createpatch"), 0, () -> {
 					Path srcPathUnpatched = MCPPaths.get(mcp, SOURCE_UNPATCHED, side);
 					Path srcPathPatched = MCPPaths.get(mcp, SOURCE, side);
-					Path patchesOut = MCPPaths.get(mcp, PATCH, side);
+					Path patchesOut = MCPPaths.get(mcp, PATCHES, side);
 					setProgress(getLocalizedStage("createpatch"));
 					if (!Files.exists(srcPathPatched)) {
 						throw new IOException("Patched " + side.name + " sources cannot be found!");

--- a/src/main/java/org/mcphackers/mcp/tasks/mode/TaskMode.java
+++ b/src/main/java/org/mcphackers/mcp/tasks/mode/TaskMode.java
@@ -139,7 +139,7 @@ public class TaskMode {
 			.setName("applypatch")
 			.setTaskClass(TaskApplyPatch.class)
 			.setProgressBars(false)
-			.addRequirement((mcp, side) -> Files.isReadable(MCPPaths.get(mcp, MCPPaths.PATCH, side))
+			.addRequirement((mcp, side) -> Files.isReadable(MCPPaths.get(mcp, MCPPaths.PATCHES, side))
 					&& Files.isReadable(MCPPaths.get(mcp, MCPPaths.SOURCE, side)))
 			.setParameters(new TaskParameter[]{
 					TaskParameter.SIDE


### PR DESCRIPTION
This PR fixes the following issue.

the Apply patches stage was looking for patches in the conf/ directory, even though create patches puts them in the patches/ directory.

this meant that the stage would never fire when toggled on and could only be completed with the applypatch cli command.

