### PR TITLE
fix: extract Classic server zip after download completes

### DIFF
--- a/src/main/java/org/mcphackers/mcp/tools/versions/DownloadData.java
+++ b/src/main/java/org/mcphackers/mcp/tools/versions/DownloadData.java
@@ -28,8 +28,6 @@ public class DownloadData {
 	public int totalSize;
 	protected List<Download> downloadQueue = new ArrayList<>();
 	protected AssetIndex assets;
-	private Path serverZip;
-	private Path serverJar;
 
 	public DownloadData(MCP mcp, Version version) {
 		this(mcp, MCPPaths.get(mcp, MCPPaths.LIB), MCPPaths.get(mcp, MCPPaths.JARS), MCPPaths.get(mcp, MCPPaths.JAR_ORIGINAL, Side.CLIENT), MCPPaths.get(mcp, MCPPaths.JAR_ORIGINAL, Side.SERVER), version);
@@ -43,12 +41,12 @@ public class DownloadData {
 		Artifact serverArtifact = version.downloads.artifacts.get("server");
 		if (mcp.getOptions().getSide().includesServer() && serverArtifact != null) {
 			Path serverOut = server;
+			Path serverExtractTo = null;
 			if (serverArtifact.url.endsWith(".zip")) {
 				serverOut = server.getParent().resolve("minecraft_server.zip");
-				this.serverZip = serverOut;
-				this.serverJar = server;
+				serverExtractTo = server;
 			}
-			queueDownload(serverArtifact, serverOut);
+			queueDownload(serverArtifact, serverOut, serverExtractTo);
 		}
 		for (DependDownload dependencyDownload : version.libraries) {
 			if (Rule.apply(dependencyDownload.rules)) {
@@ -126,11 +124,15 @@ public class DownloadData {
 	}
 
 	public void queueDownload(IDownload dl, Path baseDir) {
+		queueDownload(dl, baseDir, null);
+	}
+
+	private void queueDownload(IDownload dl, Path baseDir, Path extractTo) {
 		if (dl == null) {
 			return;
 		}
 		totalSize += dl.downloadSize();
-		downloadQueue.add(new Download(dl, baseDir));
+		downloadQueue.add(new Download(dl, baseDir, extractTo));
 	}
 
 	public void performDownload(DownloadListener listener) throws IOException {
@@ -146,14 +148,13 @@ public class DownloadData {
 				if (parent != null) Files.createDirectories(parent);
 				FileUtil.downloadFile(download.downloadURL(), file);
 			}
+			if (dl.extractTo != null) {
+				extractServerZip(file, dl.extractTo);
+			}
 		}
-		extractServerZip();
 	}
 
-	private void extractServerZip() throws IOException {
-		if (serverZip == null || !Files.exists(serverZip)) {
-			return;
-		}
+	private void extractServerZip(Path serverZip, Path serverJar) throws IOException {
 		FileUtil.extractByExtension(serverZip, serverZip.getParent(), ".jar");
 		Path extracted = serverZip.getParent().resolve("minecraft-server.jar");
 		if (Files.exists(extracted)) {
@@ -164,10 +165,12 @@ public class DownloadData {
 	private static class Download {
 		IDownload download;
 		Path dir;
+		Path extractTo;
 
-		public Download(IDownload dl, Path path) {
+		public Download(IDownload dl, Path path, Path extractTo) {
 			download = dl;
 			dir = path;
+			this.extractTo = extractTo;
 		}
 	}
 }

--- a/src/main/java/org/mcphackers/mcp/tools/versions/DownloadData.java
+++ b/src/main/java/org/mcphackers/mcp/tools/versions/DownloadData.java
@@ -28,6 +28,8 @@ public class DownloadData {
 	public int totalSize;
 	protected List<Download> downloadQueue = new ArrayList<>();
 	protected AssetIndex assets;
+	private Path serverZip;
+	private Path serverJar;
 
 	public DownloadData(MCP mcp, Version version) {
 		this(mcp, MCPPaths.get(mcp, MCPPaths.LIB), MCPPaths.get(mcp, MCPPaths.JARS), MCPPaths.get(mcp, MCPPaths.JAR_ORIGINAL, Side.CLIENT), MCPPaths.get(mcp, MCPPaths.JAR_ORIGINAL, Side.SERVER), version);
@@ -43,18 +45,10 @@ public class DownloadData {
 			Path serverOut = server;
 			if (serverArtifact.url.endsWith(".zip")) {
 				serverOut = server.getParent().resolve("minecraft_server.zip");
+				this.serverZip = serverOut;
+				this.serverJar = server;
 			}
 			queueDownload(serverArtifact, serverOut);
-			if (serverArtifact.url.endsWith(".zip")) {
-				try {
-					FileUtil.extractByExtension(serverOut, serverOut.getParent(), ".jar");
-					if (Files.exists(serverOut.getParent().resolve("minecraft-server.jar"))) {
-						Files.move(serverOut.getParent().resolve("minecraft-server.jar"), server);
-					}
-				} catch (IOException e) {
-					e.printStackTrace();
-				}
-			}
 		}
 		for (DependDownload dependencyDownload : version.libraries) {
 			if (Rule.apply(dependencyDownload.rules)) {
@@ -152,6 +146,18 @@ public class DownloadData {
 				if (parent != null) Files.createDirectories(parent);
 				FileUtil.downloadFile(download.downloadURL(), file);
 			}
+		}
+		extractServerZip();
+	}
+
+	private void extractServerZip() throws IOException {
+		if (serverZip == null || !Files.exists(serverZip)) {
+			return;
+		}
+		FileUtil.extractByExtension(serverZip, serverZip.getParent(), ".jar");
+		Path extracted = serverZip.getParent().resolve("minecraft-server.jar");
+		if (Files.exists(extracted)) {
+			Files.move(extracted, serverJar);
 		}
 	}
 


### PR DESCRIPTION
Fixes #221

## Problem

When setting up a Classic server version, `DownloadData`'s constructor calls `FileUtil.extractByExtension(...)` on `minecraft_server.zip` immediately after `queueDownload(...)`. But `queueDownload` only adds the entry to a queue - the actual download happens later, when `performDownload(...)` is called from `TaskSetup` / `TaskUpdateLibraries`.

So the extraction runs against a file that does not exist yet and throws `NoSuchFileException`. The exception is swallowed by `printStackTrace`, the constructor finishes, the zip later gets downloaded, but nothing ever extracts it. The user has to run `cleanup` and re-setup to get a working server.

## Fix

- Stash the zip path and target jar path on the instance when a `.zip` server artifact is detected.
- Move the `extractByExtension` + `Files.move` step to run at the end of `performDownload(...)`, after the zip has actually been written to disk.
- Drop the silent `printStackTrace`; the `IOException` now propagates like every other error in `performDownload`.

Behavior for non-Classic versions (where `serverArtifact.url` does not end with `.zip`) is unchanged.

## Testing

- `gradlew compileJava` - clean build, no new warnings.
