### PR TITLE
fix: abort update when no matching asset is found

### DIFF
--- a/src/main/java/org/mcphackers/mcp/tasks/TaskDownloadUpdate.java
+++ b/src/main/java/org/mcphackers/mcp/tasks/TaskDownloadUpdate.java
@@ -36,6 +36,7 @@ public class TaskDownloadUpdate extends TaskStaged {
 						boolean confirmed = mcp.updateDialogue(notes, latestVersion);
 						if (confirmed) {
 							log("Downloading update...");
+							boolean downloaded = false;
 							for (Object obj : releaseJson.getJSONArray("assets")) {
 								if (obj instanceof JSONObject) {
 									JSONObject assetObj = (JSONObject) obj;
@@ -43,8 +44,14 @@ public class TaskDownloadUpdate extends TaskStaged {
 										continue;
 									}
 									FileUtil.downloadFile(assetObj.getString("browser_download_url"), Paths.get(MCPPaths.UPDATE_JAR));
+									downloaded = true;
 									break;
 								}
+							}
+							if (!downloaded) {
+								IOException t = new IOException("No matching update asset found in release! Aborting");
+								Util.throwExceptionInIDE(t);
+								throw t;
 							}
 							Path jarPath = Paths.get(MCP.class
 									.getProtectionDomain()

--- a/src/main/java/org/mcphackers/mcp/tasks/TaskDownloadUpdate.java
+++ b/src/main/java/org/mcphackers/mcp/tasks/TaskDownloadUpdate.java
@@ -36,7 +36,6 @@ public class TaskDownloadUpdate extends TaskStaged {
 						boolean confirmed = mcp.updateDialogue(notes, latestVersion);
 						if (confirmed) {
 							log("Downloading update...");
-							boolean downloaded = false;
 							for (Object obj : releaseJson.getJSONArray("assets")) {
 								if (obj instanceof JSONObject) {
 									JSONObject assetObj = (JSONObject) obj;
@@ -44,11 +43,10 @@ public class TaskDownloadUpdate extends TaskStaged {
 										continue;
 									}
 									FileUtil.downloadFile(assetObj.getString("browser_download_url"), Paths.get(MCPPaths.UPDATE_JAR));
-									downloaded = true;
 									break;
 								}
 							}
-							if (!downloaded) {
+							if (!Files.exists(Paths.get(MCPPaths.UPDATE_JAR))) {
 								IOException t = new IOException("No matching update asset found in release! Aborting");
 								Util.throwExceptionInIDE(t);
 								throw t;


### PR DESCRIPTION
Followup to #217.

Current `TaskDownloadUpdate` filters release assets by suffix (`-GUI.jar` or `-CLI.jar`). If no asset matches (e.g. a future release with different naming, a partial release, or an asset list change on GitHub), the loop exits silently without writing `update.jar`. The code right after still launches a subprocess pointing at the missing jar and calls `System.exit(0)`, so the app just closes with no feedback - the same user-visible symptom as #217.

This adds a guard: if no matching asset is downloaded, throw an `IOException` so the failure is surfaced through the standard task error dialog instead of a silent exit.

### Changes
- Track whether the matching asset was actually downloaded
- Throw `IOException("No matching update asset found in release! Aborting")` when nothing matched
- Mirrors the existing `Running from a folder! Aborting` pattern a few lines below

### Testing
- `gradlew build` passes
- No new dependencies, no behavior change on the happy path
