### PR TITLE
fix: don't include untouched files in build output

### DIFF
--- a/src/main/java/org/mcphackers/mcp/tasks/TaskBuild.java
+++ b/src/main/java/org/mcphackers/mcp/tasks/TaskBuild.java
@@ -2,14 +2,19 @@ package org.mcphackers.mcp.tasks;
 
 import static org.mcphackers.mcp.MCPPaths.*;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
 
 import org.mcphackers.mcp.MCP;
 import org.mcphackers.mcp.MCPPaths;
 import org.mcphackers.mcp.tasks.mode.TaskParameter;
 import org.mcphackers.mcp.tools.FileUtil;
+import org.mcphackers.mcp.tools.Util;
 
 public class TaskBuild extends TaskStaged {
 	/*
@@ -40,12 +45,12 @@ public class TaskBuild extends TaskStaged {
 								Path buildJar = MCPPaths.get(mcp, BUILD_JAR, localSide);
 								Path buildZip = MCPPaths.get(mcp, BUILD_ZIP, localSide);
 								FileUtil.createDirectories(MCPPaths.get(mcp, BUILD));
+								List<Path> assets = collectChangedAssets(bin);
 								if (mcp.getOptions().getBooleanParameter(TaskParameter.FULL_BUILD)) {
 									Files.deleteIfExists(buildJar);
 									Files.copy(originalJar, buildJar);
 									List<Path> reobfClasses = FileUtil.walkDirectory(reobfDir, path -> !Files.isDirectory(path));
 									FileUtil.packFilesToZip(buildJar, reobfClasses, reobfDir);
-									List<Path> assets = FileUtil.walkDirectory(bin, path -> !Files.isDirectory(path) && !path.getFileName().toString().endsWith(".class"));
 									FileUtil.packFilesToZip(buildJar, assets, bin);
 									FileUtil.deleteFileInAZip(buildJar, "/META-INF/MOJANG_C.DSA");
 									FileUtil.deleteFileInAZip(buildJar, "/META-INF/MOJANG_C.SF");
@@ -54,12 +59,51 @@ public class TaskBuild extends TaskStaged {
 								} else {
 									Files.deleteIfExists(buildZip);
 									FileUtil.compress(reobfDir, buildZip);
-									List<Path> assets = FileUtil.walkDirectory(bin, path -> !Files.isDirectory(path) && !path.getFileName().toString().endsWith(".class"));
 									FileUtil.packFilesToZip(buildZip, assets, bin);
 								}
 							}
 						})
 		};
+	}
+
+	/**
+	 * Collects only assets (non-class resources) whose contents differ from the
+	 * hash recorded by the last MD5 update, or that have no recorded hash at all.
+	 * Avoids packaging untouched resources into the build output.
+	 */
+	private List<Path> collectChangedAssets(Path bin) throws IOException {
+		final Map<String, String> originalHashes = readMD5Hashes(MCPPaths.get(mcp, MD5, side));
+		return FileUtil.walkDirectory(bin, path -> {
+			if (Files.isDirectory(path) || path.getFileName().toString().endsWith(".class")) {
+				return false;
+			}
+			String key = bin.relativize(path).toString().replace("\\", "/");
+			String original = originalHashes.get(key);
+			if (original == null) {
+				return true;
+			}
+			try {
+				return !original.equals(Util.getMD5(path));
+			} catch (IOException e) {
+				return true;
+			}
+		});
+	}
+
+	private static Map<String, String> readMD5Hashes(Path md5File) throws IOException {
+		Map<String, String> hashes = new HashMap<>();
+		if (!Files.exists(md5File)) {
+			return hashes;
+		}
+		try (Stream<String> lines = Files.lines(md5File)) {
+			lines.forEach(line -> {
+				String[] tokens = line.split(" ");
+				if (tokens.length == 2) {
+					hashes.put(tokens[0], tokens[1]);
+				}
+			});
+		}
+		return hashes;
 	}
 
 	@Override

--- a/src/main/java/org/mcphackers/mcp/tasks/TaskReobfuscate.java
+++ b/src/main/java/org/mcphackers/mcp/tasks/TaskReobfuscate.java
@@ -101,15 +101,22 @@ public class TaskReobfuscate extends TaskStaged {
 					return false;
 				}
 				String obfClassName = entry.getName().replace(".class", "");
-				// Force inner classes to compare outer class hash
-				String className = obfClassName;
-				int index = className.indexOf('$');
-				if (index != -1) {
-					className = className.substring(0, index);
-				}
-				String deobfName = reversedNames.get(className);
+				// Try to resolve the deobfuscated name. If the inner-class entry
+				// has no direct mapping, fall back to the outer class.
+				String deobfName = reversedNames.get(obfClassName);
 				if (deobfName == null) {
-					deobfName = className;
+					int dollar = obfClassName.indexOf('$');
+					if (dollar != -1) {
+						deobfName = reversedNames.get(obfClassName.substring(0, dollar));
+					}
+					if (deobfName == null) {
+						deobfName = obfClassName;
+					}
+				}
+				// MD5 hashes are recorded per outer class, so strip any inner-class suffix.
+				int innerIdx = deobfName.indexOf('$');
+				if (innerIdx != -1) {
+					deobfName = deobfName.substring(0, innerIdx);
 				}
 				String hash = originalHashes.get(deobfName);
 				String hashModified = recompHashes.get(deobfName);


### PR DESCRIPTION
Fixes #237.

Two bugs were causing unmodified files to leak into build output (e.g. user reports `gui/items.png`, `terrain.png`, `ItemArmor$EnumArmorMaterial.class`, `TileEntityFurnace$1.class` ending up in the zip even though they weren't touched after the MD5 update).

### Bug 1 - Inner classes always extracted in `TaskReobfuscate`

The `FileUtil.extract` filter stripped `$...` from the obfuscated entry name, then looked the result up in `reversedNames` (a map keyed by obfuscated outer-class names). Inner classes have entries like `ItemArmor$EnumArmorMaterial`, and stripping the inner suffix gives `ItemArmor` - which isn't in the obfuscated map. The lookup returned null, the code fell back to using the obfuscated name as the deobf name, the hash lookup also missed, and `extract` was forced to true unconditionally.

Fix: resolve the deobfuscated name first (try the full entry name, then fall back to the outer class), then strip the inner-class suffix from that deobf name to build the hash key.

### Bug 2 - Asset files never compared against MD5

`TaskBuild` walked every non-class file under `bin/` and packed it into the build zip with no hash check, so any asset that was just a copy of the original (e.g. an unmodified `terrain.png` left over from the source layout) was always bundled. `TaskUpdateMD5` already records hashes for these files, the build step just wasn't reading them.

Fix: in `TaskBuild`, read the original MD5 file once and only include assets whose current hash differs from the recorded one (or that have no recorded hash, i.e. genuinely new files).

### Testing
- `gradlew build` passes
- No new dependencies
- Same code path on the happy case (modified files still get packaged); only unmodified files are now excluded
